### PR TITLE
Add Noto Sans SC/TC/JP/KR and Noto Serif [CJK] SC/TC/JP/KR

### DIFF
--- a/59-family-prefer-lang-specific.conf
+++ b/59-family-prefer-lang-specific.conf
@@ -16,6 +16,7 @@
 			<string>zh-cn</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans SC</string>
 			<string>Noto Sans CJK SC</string>
 		</edit>
 	</match>
@@ -27,6 +28,8 @@
 		  <string>zh-cn</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Serif SC</string>
+			<string>Noto Serif CJK SC</string>
 			<string>AR PL UMing CN</string>
 		</edit>
 	</match>
@@ -49,6 +52,7 @@
 			<string>zh-sg</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans SC</string>
 			<string>Noto Sans CJK SC</string>
 		</edit>
 	</match>
@@ -60,6 +64,8 @@
 		<string>zh-sg</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Serif SC</string>
+			<string>Noto Serif CJK SC</string>
 			<string>AR PL UMing CN</string>
 		</edit>
 	</match>
@@ -95,6 +101,8 @@
 			<string>zh-tw</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Serif TC</string>
+			<string>Noto Serif CJK TC</string>
 			<string>AR PL UMing TW</string>
 		</edit>
 	</match>
@@ -117,6 +125,7 @@
 			<string>zh-hk</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans TC</string>
 			<string>Noto Sans CJK TC</string>
 		</edit>
 	</match>
@@ -128,6 +137,8 @@
 			<string>zh-hk</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Serif TC</string>
+			<string>Noto Serif CJK TC</string>
 			<string>AR PL UMing HK</string>
 		</edit>
 	</match>
@@ -150,6 +161,7 @@
 			<string>zh-mo</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans TC</string>
 			<string>Noto Sans CJK TC</string>
 		</edit>
 	</match>
@@ -161,6 +173,8 @@
 			<string>zh-mo</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Serif TC</string>
+			<string>Noto Serif CJK TC</string>
 			<string>CMEXSong</string>
 			<string>AR PL UMing HK</string>
 		</edit>
@@ -186,6 +200,7 @@
 			<string>ko</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans KR</string>
 			<string>Noto Sans CJK KR</string>
 			<string>NanumGothic</string>
 		</edit>
@@ -198,6 +213,8 @@
 		<string>ko</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Serif KR</string>
+			<string>Noto Serif CJK KR</string>
 			<string>NanumMyeongjo</string>
 		</edit>
 	</match>
@@ -228,6 +245,7 @@
 			<string>M+ 1c</string>
 			<string>M+ 1p</string>
 			<string>VL PGothic</string>
+			<string>Noto Sans JP</string>
 			<string>Noto Sans CJK JP</string>
 			<string>IPAGothic</string>
 		</edit>
@@ -242,6 +260,8 @@
 		<edit name="family" mode="prepend">
 			<string>IPAPMincho</string>
 			<string>IPAexMincho</string>
+			<string>Noto Serif JP</string>
+			<string>Noto Serif CJK JP</string>
 			<string>IPAMincho</string>
 		</edit>
 	</match>


### PR DESCRIPTION
Add Noto Sans SC/TC/JP/KR and Noto Serif [CJK] SC/TC/JP/KR to 59-family-prefer-lang-specific.conf

This is minimal fix for Sans alias under environment with Noto Sans SC/TC/JP/KR.