### PR TITLE
Allow non-ASCII letters in font names (boo#1049056)

### DIFF
--- a/fonts-config
+++ b/fonts-config
@@ -654,7 +654,7 @@ sub get_option_defaults_from_sysconfig {
       elsif (eval ("\$$i") =~ /^[0-9]+$/) { # Type integer
         eval("\$$sysconfig_options{$i}=\$$i");
       }
-      elsif (eval ("\$$i") =~ /^[-:a-zA-Z0-9 &,]+$/) { # Type string
+      elsif (eval ("\$$i") =~ /^[-:\p{L}0-9 &,]+$/) { # Type string
         eval("\$$sysconfig_options{$i}=\$$i");
       }
       else { # this case also occurs when the variable is the empty string!


### PR DESCRIPTION
This allows fonts that use localized names to be selected from the installed fonts picker. An example of this is "VL Gothic", where the Japanese localized name is "VL ゴシック".

Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1049056