### PR TITLE
Avoid hinting emoji fonts

### DIFF
--- a/21-emoji-rendering.conf
+++ b/21-emoji-rendering.conf
@@ -1,13 +1,17 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
+  <match target="font">
+    <test qual="any" name="family" compare="eq">
+	    <string>emoji</string>
+    </test>
     <!-- most emoji fonts rely on embeddedbitmap boo#1085769 -->
-    <match target="font">
-      <test qual="any" name="family" compare="eq">
-	<string>emoji</string>
-      </test>
-      <edit name="embeddedbitmap" mode="assign">
-	<bool>true</bool>
-      </edit>
-    </match>
+    <edit name="embeddedbitmap" mode="assign">
+	    <bool>true</bool>
+    </edit>
+    <!-- Firefox doesn't render Noto Color Emoji if hinting is enabled -->
+    <edit name="hintstyle" mode="assign">
+      <const>hintnone</const>
+    </edit>
+  </match>
 </fontconfig>


### PR DESCRIPTION
Firefox doesn't render Noto Color Emoji if hinting is enabled