### PR TITLE
Fix #15 Reject Twemoji Mozilla

### DIFF
--- a/32-emoji-reject.conf
+++ b/32-emoji-reject.conf
@@ -8,6 +8,11 @@
           <string>EmojiOne Mozilla</string>
         </patelt>
       </pattern>
+      <pattern>
+        <patelt name="family">
+          <string>Twemoji Mozilla</string>
+        </patelt>
+      </pattern>
     </rejectfont>
   </selectfont>
 </fontconfig>


### PR DESCRIPTION
Twemoji Mozilla is Mozilla Firefox's built in emoji fonts.