### PR TITLE
Fix en-US, en-GB font matching

### DIFF
--- a/65-language-variants.conf
+++ b/65-language-variants.conf
@@ -1,0 +1,12 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+	<!--
+		Fix bug of en-US, en-GB font matching, fallback to en instead of system language
+		See https://gitlab.freedesktop.org/fontconfig/fontconfig/issues/155
+	-->
+	<match>
+		<test name="lang" compare="contains"><string>en</string></test>
+		<edit name="lang" mode="assign" binding="same"><string>en</string></edit>
+	</match>
+</fontconfig>


### PR DESCRIPTION
fallback to en instead of system language

See https://gitlab.freedesktop.org/fontconfig/fontconfig/issues/155