### PR TITLE
widen comparison operator for emoji fonts

### DIFF
--- a/21-emoji-rendering.conf
+++ b/21-emoji-rendering.conf
@@ -3,11 +3,11 @@
 <fontconfig>
     <!-- most emoji fonts rely on embeddedbitmap boo#1085769 -->
     <match target="font">
-      <test qual="any" name="family" compare="eq">
-	<string>emoji</string>
+      <test qual="any" name="family" compare="contains">
+        <string>emoji</string>
       </test>
       <edit name="embeddedbitmap" mode="assign">
-	<bool>true</bool>
+        <bool>true</bool>
       </edit>
     </match>
 </fontconfig>


### PR DESCRIPTION
This is needed to match fonts like `Noto Color Emoji`.

Also fixes the indentation in this file. 