### PR TITLE
Add variable to allow fonts-config to update default settings

### DIFF
--- a/sysconfig.fonts-config
+++ b/sysconfig.fonts-config
@@ -239,3 +239,13 @@ GENERATE_TTCAP_ENTRIES="yes"
 #
 GENERATE_JAVA_FONT_SETUP="yes"
 
+## Path:        Desktop
+## Description: Modify the default settings in the next fonts-config package update
+## Type:        yesno
+## Default:     no
+#
+# If set to "yes", the fonts-config package will modify the default
+# settings in this file when the package is updated the next time.
+# After doing so, the variable will be set to "no" again.
+#
+FORCE_MODIFY_DEFAULT_FONT_SETTINGS_IN_NEXT_UPDATE="no"


### PR DESCRIPTION
This variable tells the %post scriptlet of the fonts-config
package if it should update the settings in
/etc/sysconfig/fonts-config with the default values. The
FORCE_MODIFY_DEFAULT_FONT_SETTINGS_IN_NEXT_UPDATE variable would
rarely be set to "yes" but the fact that the value doesn't exist
in a system would already tell the package the default settings
should be changed once.

This is done this way because fillup doesn't modify existing values
from the changed templates, but we want users to have the latest
default values.

This (and the associated change in the %post scriptlet in
fonts-config) should fix boo#1172022.