### PR TITLE
feat: add Noto HK fonts to conf

### DIFF
--- a/59-family-prefer-lang-specific.conf
+++ b/59-family-prefer-lang-specific.conf
@@ -43,9 +43,10 @@
 		<edit name="family" mode="prepend" binding="strong">
 			<string>Noto Sans SC</string>
 			<string>Noto Sans TC</string>
+			<string>Noto Sans HK</string>
 			<string>Noto Sans JP</string>
 			<string>Noto Sans KR</string>
-      <string>Noto Sans CJK SC</string>
+                        <string>Noto Sans CJK SC</string>
     </edit>
 	</match>
 	<match target="pattern">
@@ -58,6 +59,7 @@
 		<edit name="family" mode="prepend" binding="strong">
 			<string>Noto Serif SC</string>
 			<string>Noto Serif TC</string>
+			<string>Noto Serif HK</string>
 			<string>Noto Serif JP</string>
 			<string>Noto Serif KR</string>
 			<string>Noto Serif CJK SC</string>
@@ -84,6 +86,7 @@
 		<edit name="family" mode="prepend" binding="strong">
 			<string>Noto Sans SC</string>
 			<string>Noto Sans TC</string>
+			<string>Noto Sans HK</string>
 			<string>Noto Sans JP</string>
 			<string>Noto Sans KR</string>
 			<string>Noto Sans CJK SC</string>
@@ -99,6 +102,7 @@
 		<edit name="family" mode="prepend" binding="strong">
 			<string>Noto Serif SC</string>
 			<string>Noto Serif TC</string>
+			<string>Noto Serif HK</string>
 			<string>Noto Serif JP</string>
 			<string>Noto Serif KR</string>
 			<string>Noto Serif CJK SC</string>
@@ -126,10 +130,12 @@
 		</test>
 		<edit name="family" mode="prepend" binding="strong">
 			<string>Noto Sans TC</string>
+			<string>Noto Sans HK</string>
 			<string>Noto Sans SC</string>
 			<string>Noto Sans JP</string>
 			<string>Noto Sans KR</string>
 			<string>Noto Sans CJK TC</string>
+			<string>Noto Sans CJK HK</string>
 		</edit>
 	</match>
 	<match target="pattern">
@@ -141,10 +147,12 @@
 		</test>
 		<edit name="family" mode="prepend" binding="strong">
 			<string>Noto Serif TC</string>
+			<string>Noto Serif HK</string>
 			<string>Noto Serif SC</string>
 			<string>Noto Serif JP</string>
 			<string>Noto Serif KR</string>
 			<string>Noto Serif CJK TC</string>
+			<string>Noto Serif CJK HK</string>
 		</edit>
 	</match>
 	<match target="pattern">
@@ -156,6 +164,7 @@
 		</test>
 		<edit name="family" mode="prepend">
 			<string>Noto Sans Mono CJK TC</string>
+			<string>Noto Sans Mono CJK HK</string>
 		</edit>
 	</match>
 	<match target="pattern">
@@ -166,10 +175,12 @@
 			<string>zh-hk</string>
 		</test>
 		<edit name="family" mode="prepend" binding="strong">
+			<string>Noto Sans HK</string>
 			<string>Noto Sans TC</string>
 			<string>Noto Sans SC</string>
 			<string>Noto Sans JP</string>
 			<string>Noto Sans KR</string>
+			<string>Noto Sans CJK HK</string>
 			<string>Noto Sans CJK TC</string>
 		</edit>
 	</match>
@@ -181,10 +192,12 @@
 			<string>zh-hk</string>
 		</test>
 		<edit name="family" mode="prepend" binding="strong">
+			<string>Noto Serif HK</string>
 			<string>Noto Serif TC</string>
 			<string>Noto Serif SC</string>
 			<string>Noto Serif JP</string>
 			<string>Noto Serif KR</string>
+			<string>Noto Serif CJK HK</string>
 			<string>Noto Serif CJK TC</string>
 		</edit>
 	</match>
@@ -196,6 +209,7 @@
 			<string>zh-hk</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans Mono CJK HK</string>
 			<string>Noto Sans Mono CJK TC</string>
 		</edit>
 	</match>
@@ -207,10 +221,12 @@
 			<string>zh-mo</string>
 		</test>
 		<edit name="family" mode="prepend" binding="strong">
+			<string>Noto Sans HK</string>
 			<string>Noto Sans TC</string>
 			<string>Noto Sans SC</string>
 			<string>Noto Sans JP</string>
 			<string>Noto Sans KR</string>
+			<string>Noto Sans CJK HK</string>
 			<string>Noto Sans CJK TC</string>
 		</edit>
 	</match>
@@ -222,10 +238,12 @@
 			<string>zh-mo</string>
 		</test>
 		<edit name="family" mode="prepend" binding="strong">
+			<string>Noto Serif HK</string>
 			<string>Noto Serif TC</string>
 			<string>Noto Serif SC</string>
 			<string>Noto Serif JP</string>
 			<string>Noto Serif KR</string>
+			<string>Noto Serif CJK HK</string>
 			<string>Noto Serif CJK TC</string>
       <string>CMEXSong</string>
 		</edit>
@@ -238,6 +256,7 @@
 			<string>zh-mo</string>
 		</test>
 		<edit name="family" mode="prepend">
+			<string>Noto Sans Mono CJK HK</string>
 			<string>Noto Sans Mono CJK TC</string>
 		</edit>
 	</match>
@@ -254,6 +273,7 @@
 			<string>Noto Sans KR</string>
 			<string>Noto Sans JP</string>
 			<string>Noto Sans TC</string>
+			<string>Noto Sans HK</string>
 			<string>Noto Sans SC</string>
 			<string>Noto Sans CJK KR</string>
 			<string>NanumGothic</string>
@@ -270,6 +290,7 @@
 			<string>Noto Serif KR</string>
 			<string>Noto Serif JP</string>
 			<string>Noto Serif TC</string>
+			<string>Noto Serif HK</string>
 			<string>Noto Serif SC</string>
       <string>Noto Serif CJK KR</string>
 			<string>NanumMyeongjo</string>
@@ -303,9 +324,10 @@
 			<string>M+ 1p</string>
 			<string>VL PGothic</string>
 			<string>Noto Sans JP</string>
-			<string>Noto Sans TC</string>
-			<string>Noto Sans SC</string>
 			<string>Noto Sans KR</string>
+			<string>Noto Sans TC</string>
+			<string>Noto Sans HK</string>
+			<string>Noto Sans SC</string>
 			<string>Noto Sans CJK JP</string>
 			<string>IPAGothic</string>
 		</edit>
@@ -321,10 +343,11 @@
 			<string>IPAPMincho</string>
 			<string>IPAexMincho</string>
 			<string>Noto Serif JP</string>
-			<string>Noto Serif TC</string>
-			<string>Noto Serif SC</string>
 			<string>Noto Serif KR</string>
-      <string>Noto Serif CJK JP</string>
+			<string>Noto Serif TC</string>
+			<string>Noto Serif HK</string>
+			<string>Noto Serif SC</string>
+                        <string>Noto Serif CJK JP</string>
 			<string>IPAMincho</string>
 		</edit>
 	</match>


### PR DESCRIPTION
- Hong Kong and Macau are very close both physically and culturally so they should both prioritize Noto HK fonts
- Also changed the position of Noto KR to be higher for JP cause I think it should be higher than the Chinese variants of Noto for JP
- ~~Note that this is affected by https://bugzilla.opensuse.org/show_bug.cgi?id=1201571 as currently, Noto Serif CJK HK fonts are not installable on openSUSE. (but not blocked as that just means for now zh-hk and zh-mo users will default to Noto Serif CJK TC fonts)~~
-  The above has been fixed now as Noto Serif CJK HK fonts are now available