### PR TITLE
get the homedir from getpwuid when no $ENV{"HOME"} set

### DIFF
--- a/fonts-config
+++ b/fonts-config
@@ -388,7 +388,8 @@ my %sysconfig_options = (
                          "GENERATE_JAVA_FONT_SETUP"       , "OPT_JAVA",
                         );
 
-my $xdg_prefix = "$ENV{HOME}/.config/";
+my $homedir = defined $ENV{"HOME"} ? $ENV{"HOME"} : (getpwuid $>)[7];
+my $xdg_prefix = "$homedir/.config/";
 my %files = (
                  "sysconfig file",                      "/etc/sysconfig/fonts-config",
                  "user sysconfig file",                 "fontconfig/fonts-config",


### PR DESCRIPTION
Fix
```
Use of uninitialized value $ENV{"HOME"} in concatenation (.) or string at /usr/sbin/fonts-config line 391.
```
Internal bug reference: [bsc#1210700](https://bugzilla.suse.com/show_bug.cgi?id=1210700)