### PR TITLE
Fix typos in 32-emoji-reject.conf and 59-family-prefer-lang-specific

### DIFF
--- a/32-emoji-reject.conf
+++ b/32-emoji-reject.conf
@@ -23,6 +23,6 @@
           <string>Noto Emoji</string>
         </patelt>
       </pattern>
-    <rejectfont>
+    </rejectfont>
   </selectfont>
 </fontconfig>

--- a/59-family-prefer-lang-specific-cjk.conf
+++ b/59-family-prefer-lang-specific-cjk.conf
@@ -162,7 +162,7 @@
     </test>
     <edit name="family" mode="prepend">
       <string>Noto Serif SC</string>
-      <string>Noto Serif HK</stirng>
+      <string>Noto Serif HK</string>
       <string>Noto Serif TC</string>
       <string>Noto Serif JP</string>
       <string>Noto Serif KR</string>
@@ -194,7 +194,7 @@
     </test>
     <edit name="family" mode="prepend">
       <string>Noto Serif TC</string>
-      <string>Noto Serif HK</stirng>
+      <string>Noto Serif HK</string>
       <string>Noto Serif JP</string>
       <string>Noto Serif KR</string>
       <string>Noto Serif SC</string>


### PR DESCRIPTION
Fix typos as fc-cache complained:
  Fontconfig error: "/etc/fonts/conf.d/32-emoji-reject.conf", line 27: mismatched tag
  Fontconfig error: "/etc/fonts/conf.d/59-family-prefer-lang-specific-cjk.conf", line 165: mismatched tag
  Fontconfig warning: "/etc/fonts/conf.d/59-family-prefer-lang-specific-cjk.conf", line 165: invalid attribute 'name'
  Fontconfig warning: "/etc/fonts/conf.d/59-family-prefer-lang-specific-cjk.conf", line 165: invalid attribute 'mode'